### PR TITLE
Remove update of currentIndex in moveIt()

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -37,9 +37,6 @@ function moveIt(tab, event) {
   if (Number.isInteger(currentIndex[tab.windowId])) {
     const moveToIndex = currentIndex[tab.windowId] + 1;
 
-    // Current is where it will move :-)
-    currentIndex[tab.windowId] = moveToIndex;
-
     // Nothing to do
     if (tab.index === moveToIndex) {
       console.log(tab.windowId + ' - chrome.tabs.' + event + ' - tab.index: ' + tab.index + ' == moveToIndex: ' + moveToIndex + ' (nothing to do)');


### PR DESCRIPTION
**Situation:**
Say I'm on `tab 1`, and I open `link A` in a new tab from `tab 1` and then open `link B` in a new tab from `tab 1`.

**Expected:**
I expect `link B` to be on `tab 2` and `link A` to be on `tab 3`.

**Actual:**
Most of the time `link A` will be on `tab 2` and `link B` on `tab 3`.  
Sometimes, if I switch window and then re-focus back on the window between opening `link A` and `link B`, `link B` will be on `tab 2` and `link A` will be on `tab 3`.