### PR TITLE
Workaround for the scrollable tabstrip issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-new-tab-after-current-tab",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "open-new-tab-after-current-tab",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "devDependencies": {
         "chrome-webstore-upload-cli": "^2.2",
@@ -2220,7 +2220,6 @@
       "resolved": "https://registry.npmjs.org/chrome-webstore-upload-cli/-/chrome-webstore-upload-cli-2.2.2.tgz",
       "integrity": "sha512-Y6q5gZ3xp+b9rPgw0SNmW7tOgx0qhHpz2NloaoDe8/f45GiqZiH3gAhyYeekY75RcwG3LT1wNmbjMdSKf7n8fg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chrome-webstore-upload": "^1.0.0",
         "junk": "^4.0.0",
@@ -2997,7 +2996,6 @@
       "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
       "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "globby": "^11.0.1",
         "graceful-fs": "^4.2.4",
@@ -10830,7 +10828,6 @@
       "resolved": "https://registry.npmjs.org/xo/-/xo-0.56.0.tgz",
       "integrity": "sha512-ohzSqgQ8POgZ3KNaEK/gxDovb6h3cglxv8+xi9Dn7gmRe8g4qotpOZpMs5ACJhvkJDmJOhiKbk6Uq6Mx1Di9DA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^2.1.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-new-tab-after-current-tab",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Opens new tab after the active tab, instead of last position.",
   "homepage": "https://dev.ligny.org/Open-New-Tab-After-Current-Tab/",
   "author": "Arnaud Ligny",

--- a/src/background.js
+++ b/src/background.js
@@ -60,11 +60,12 @@ function moveIt(tab, event) {
 
     chrome.tabs.move(tab.id, {
       index: moveToIndex,
-    }, (movedTab) => {
-        // workaround for the Chrome and Edge scrollable tabstrip issue
-        chrome.tabs.update(movedTab.openerTabId, { 'active': true }, () => {
-            chrome.tabs.update(movedTab.id, { 'active': true });
-        });
+    }, movedTab => {
+      // workaround for the Chrome and Edge scrollable tabstrip issue
+      chrome.tabs.update(movedTab.openerTabId, {active: true}, () => {
+        console.log(tab.windowId + ': active moved tab');
+        chrome.tabs.update(movedTab.id, {active: true});
+      });
     });
     if (currentGroup !== '-1') {
       chrome.tabs.group({

--- a/src/background.js
+++ b/src/background.js
@@ -60,6 +60,11 @@ function moveIt(tab, event) {
 
     chrome.tabs.move(tab.id, {
       index: moveToIndex,
+    }, (movedTab) => {
+        // workaround for the Chrome and Edge scrollable tabstrip issue
+        chrome.tabs.update(movedTab.openerTabId, { 'active': true }, () => {
+            chrome.tabs.update(movedTab.id, { 'active': true });
+        });
     });
     if (currentGroup !== '-1') {
       chrome.tabs.group({

--- a/src/background.js
+++ b/src/background.js
@@ -61,7 +61,7 @@ function moveIt(tab, event) {
     chrome.tabs.move(tab.id, {
       index: moveToIndex,
     }, movedTab => {
-      // workaround for the Chrome and Edge scrollable tabstrip issue
+      // Workaround for the Chrome and Edge scrollable tabstrip issue
       chrome.tabs.update(movedTab.openerTabId, {active: true}, () => {
         console.log(tab.windowId + ': active moved tab');
         chrome.tabs.update(movedTab.id, {active: true});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Open New Tab After Current Tab",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "__MSG_extDescription__",
   "homepage_url": "https://dev.ligny.org/Open-New-Tab-After-Current-Tab/",
   "author": "Arnaud Ligny",


### PR DESCRIPTION
This workaround should solve the issues #38 and #35. This has been driving me crazy as I usually have a huge amount of tabs opened, so every time I opened a new tab, I had to scroll all the way from the end of the tabs bar to wherever the new tab was opened.
What it does is: once the new tab is moved, activate the opener tab (the tab that originated the new tab) and then activate the new tab once again. This forces the browser to update the tabs bar scrolling.
There might be an issue if the `tab.openerTabId` is not available though.